### PR TITLE
Fix append memory allocation

### DIFF
--- a/c02/main.c
+++ b/c02/main.c
@@ -48,13 +48,13 @@ Array *append(Array *arr, int new_value) {
 
   Array *new_arr = malloc(sizeof(Array));
 
-
-  new_arr->len = arr->len + 1;
+  new_arr->len = arr->len;
   new_arr->cap = arr->cap * 2;
-  int new_p[new_arr->cap];
+  int *new_p = malloc(sizeof(int) * new_arr->cap);
   new_arr->p = new_p;
   copy(arr, new_arr);
-  new_arr->p[new_arr->len-1] = new_value;
+  new_arr->p[new_arr->len] = new_value;
+  new_arr->len++;
 
   return new_arr;
 }


### PR DESCRIPTION
## Summary
- avoid returning a pointer to stack memory when expanding an array

## Testing
- `gcc c02/main.c -o c02/app && ./c02/app`

------
https://chatgpt.com/codex/tasks/task_e_683fec70bce0832eadf8fc393060f4e3