### PR TITLE
Add jest tests for crud_tasks API

### DIFF
--- a/crud_tasks/api/tasks.test.mjs
+++ b/crud_tasks/api/tasks.test.mjs
@@ -1,0 +1,59 @@
+import { jest } from '@jest/globals'
+
+jest.unstable_mockModule('./base.mjs', () => ({
+  apiRequest: jest.fn(),
+}))
+
+const { getList, getItem, createItem, updateItem, deleteItem } = await import('./tasks.mjs')
+const { apiRequest } = await import('./base.mjs')
+
+describe('tasks API helpers', () => {
+  beforeEach(() => {
+    apiRequest.mockReset()
+  })
+
+  test('getList fetches all tasks', async () => {
+    apiRequest.mockResolvedValue('all')
+    const result = await getList()
+    expect(apiRequest).toHaveBeenCalledWith('/api/v1/tasks')
+    expect(result).toBe('all')
+  })
+
+  test('getItem fetches a single task', async () => {
+    apiRequest.mockResolvedValue('single')
+    const result = await getItem(1)
+    expect(apiRequest).toHaveBeenCalledWith('/api/v1/tasks/1')
+    expect(result).toBe('single')
+  })
+
+  test('createItem posts new task', async () => {
+    const data = { title: 't' }
+    apiRequest.mockResolvedValue('created')
+    const result = await createItem(data)
+    expect(apiRequest).toHaveBeenCalledWith('/api/v1/tasks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    expect(result).toBe('created')
+  })
+
+  test('updateItem patches existing task', async () => {
+    const data = { title: 'u' }
+    apiRequest.mockResolvedValue('updated')
+    const result = await updateItem(2, data)
+    expect(apiRequest).toHaveBeenCalledWith('/api/v1/tasks/2', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    expect(result).toBe('updated')
+  })
+
+  test('deleteItem removes a task', async () => {
+    apiRequest.mockResolvedValue(true)
+    const result = await deleteItem(3)
+    expect(apiRequest).toHaveBeenCalledWith('/api/v1/tasks/3', { method: 'DELETE' })
+    expect(result).toBe(true)
+  })
+})

--- a/crud_tasks/package.json
+++ b/crud_tasks/package.json
@@ -2,8 +2,9 @@
   "name": "crud_tasks",
   "version": "1.0.0",
   "main": "index.js",
+  "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -12,5 +13,12 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.15.1",
     "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "extensionsToTreatAsEsm": [".mjs"]
   }
 }


### PR DESCRIPTION
## Summary
- add Jest dev setup and update test script
- provide tests for API helper functions in `crud_tasks/api/tasks.mjs`

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871d4bd130c832eaa382c265bfd69fb