### PR TITLE
Remove unnecessary Jest ESM option

### DIFF
--- a/crud_tasks/package.json
+++ b/crud_tasks/package.json
@@ -12,5 +12,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.15.1",
     "zod": "^3.25.76"
+  },
+  "jest": {
+    "testEnvironment": "node"
   }
 }


### PR DESCRIPTION
## Summary
- update jest config in `crud_tasks` to only specify the node environment

## Testing
- `npm test` (fails: no tests specified)

------
https://chatgpt.com/codex/tasks/task_e_6871d7abf3ac832e82532712432f1d7e