### PR TITLE
Add Playwright E2E tests for r01 users CRUD

### DIFF
--- a/r01/.gitignore
+++ b/r01/.gitignore
@@ -41,3 +41,5 @@ config/environments/*.local.yml
 tmp/
 
 node_modules
+
+test-results

--- a/r01/README.md
+++ b/r01/README.md
@@ -40,7 +40,7 @@ $ aws lambda --endpoint-url=http://localhost:4566 --profile localstack invoke --
 
 ```bash
 # 依存関係インストール
-$ cd r01/e2e
+$ cd e2e
 $ npm install
 
 # ブラウザのインストール

--- a/r01/README.md
+++ b/r01/README.md
@@ -35,3 +35,16 @@ $ aws s3 ls --endpoint-url=http://localhost:4566 --profile localstack s3://micro
 ```bash
 $ aws lambda --endpoint-url=http://localhost:4566 --profile localstack invoke --function-name my_lambda_function result.log
 ```
+
+## Playwright E2E テスト
+
+```bash
+# 依存関係インストール
+$ cd r01/e2e
+$ npm install
+
+# 別ターミナルで r01 を起動後に実行
+$ npm test
+```
+
+必要に応じて接続先は `PLAYWRIGHT_BASE_URL` で変更できます。

--- a/r01/README.md
+++ b/r01/README.md
@@ -43,6 +43,12 @@ $ aws lambda --endpoint-url=http://localhost:4566 --profile localstack invoke --
 $ cd r01/e2e
 $ npm install
 
+# ブラウザのインストール
+$ npx playwright install
+
+# システム依存ライブラリのインストール
+$ npx playwright install-deps
+
 # 別ターミナルで r01 を起動後に実行
 $ npm test
 ```

--- a/r01/devbox.json
+++ b/r01/devbox.json
@@ -1,6 +1,9 @@
 {
-  "$schema":  "https://raw.githubusercontent.com/jetify-com/devbox/0.16.0/.schema/devbox.schema.json",
-  "packages": ["ruby@3.2.2"],
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.16.0/.schema/devbox.schema.json",
+  "packages": [
+    "ruby@3.2.2",
+    "nodejs@20.19.2"
+  ],
   "shell": {
     "init_hook": [
       "echo 'Welcome to devbox!' > /dev/null"

--- a/r01/devbox.lock
+++ b/r01/devbox.lock
@@ -5,6 +5,87 @@
       "last_modified": "2026-02-10T02:06:53Z",
       "resolved": "github:NixOS/nixpkgs/49d75834011c94a120a9cb874ac1c4d8b7bfc767?lastModified=1770689213&narHash=sha256-N6JiSpfi0s8NjUTnjwo3c%2BYAmvYhCDzjCKCrTUC97xM%3D"
     },
+    "nodejs@20.19.2": {
+      "last_modified": "2025-06-30T02:52:09Z",
+      "plugin_version": "0.0.2",
+      "resolved": "github:NixOS/nixpkgs/b95255df2360a45ddbb03817a68869d5cb01bf96#nodejs_20",
+      "source": "devbox-search",
+      "version": "20.19.2",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/bk2ccq1nwk72ag45glxzpvzkkh5a83fj-nodejs-20.19.2",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/5499fyvlwsrhamv1y8kphlb87gn16ja2-nodejs-20.19.2-dev"
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/yklpxdif067phm9g8dygjgq8s75b4hlp-nodejs-20.19.2-libv8"
+            }
+          ],
+          "store_path": "/nix/store/bk2ccq1nwk72ag45glxzpvzkkh5a83fj-nodejs-20.19.2"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/igk19nk1p66v0bf9y2kbp11dwgpnyqh5-nodejs-20.19.2",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/mw1ws43grcfmbi1rz0r0dlcwmg0hczhf-nodejs-20.19.2-dev"
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/8smmnly549yz3xxnfa5018i464bq13id-nodejs-20.19.2-libv8"
+            }
+          ],
+          "store_path": "/nix/store/igk19nk1p66v0bf9y2kbp11dwgpnyqh5-nodejs-20.19.2"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/asa518igxqzm6dy6f8yp39gr90wlz316-nodejs-20.19.2",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/nmmjadkcwl0pn0s3acbav6x2iahhgzdc-nodejs-20.19.2-dev"
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/c4gwbhgd3mjmm687y1vnmydb67v0capn-nodejs-20.19.2-libv8"
+            }
+          ],
+          "store_path": "/nix/store/asa518igxqzm6dy6f8yp39gr90wlz316-nodejs-20.19.2"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/v5m05qvmza8b8922n42mgsisb05zllm3-nodejs-20.19.2",
+              "default": true
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/nsjk4fc9rp6im3c5w7hdrb7krfs0195w-nodejs-20.19.2-libv8"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/zfkwx3mw9fbgsbj7nmb637ndf3gf8zvr-nodejs-20.19.2-dev"
+            }
+          ],
+          "store_path": "/nix/store/v5m05qvmza8b8922n42mgsisb05zllm3-nodejs-20.19.2"
+        }
+      }
+    },
     "ruby@3.2.2": {
       "last_modified": "2024-01-14T03:55:27Z",
       "plugin_version": "0.0.2",

--- a/r01/e2e/package-lock.json
+++ b/r01/e2e/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "r01-e2e",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "r01-e2e",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.54.2"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/r01/e2e/package.json
+++ b/r01/e2e/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "r01-e2e",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:ui": "playwright test --ui"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.54.2"
+  }
+}

--- a/r01/e2e/playwright.config.js
+++ b/r01/e2e/playwright.config.js
@@ -1,0 +1,18 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: false,
+  retries: process.env.CI ? 2 : 0,
+  reporter: 'list',
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:3000',
+    trace: 'on-first-retry'
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] }
+    }
+  ]
+});

--- a/r01/e2e/tests/users-crud.spec.js
+++ b/r01/e2e/tests/users-crud.spec.js
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+
+const userName = `playwright-user-${Date.now()}`;
+
+test('users CRUD がブラウザ経由で動作する', async ({ page }) => {
+  await page.goto('/users');
+
+  await expect(page.getByRole('heading', { name: 'Users' })).toBeVisible();
+
+  await page.getByRole('link', { name: 'New user' }).click();
+  await expect(page.getByRole('heading', { name: 'New user' })).toBeVisible();
+
+  await page.getByLabel('Name').fill(userName);
+  await page.getByRole('button', { name: 'Create User' }).click();
+
+  await expect(page.getByText('User was successfully created.')).toBeVisible();
+  await expect(page.getByText(userName)).toBeVisible();
+
+  await page.getByRole('link', { name: 'Edit this user' }).click();
+  await expect(page.getByRole('heading', { name: 'Editing user' })).toBeVisible();
+
+  const updatedUserName = `${userName}-updated`;
+  await page.getByLabel('Name').fill(updatedUserName);
+  await page.getByRole('button', { name: 'Update User' }).click();
+
+  await expect(page.getByText('User was successfully updated.')).toBeVisible();
+  await expect(page.getByText(updatedUserName)).toBeVisible();
+
+  page.on('dialog', (dialog) => dialog.accept());
+  await page.getByRole('button', { name: 'Destroy this user' }).click();
+
+  await expect(page.getByText('User was successfully destroyed.')).toBeVisible();
+  await expect(page.getByRole('link', { name: 'New user' })).toBeVisible();
+});


### PR DESCRIPTION
### Motivation

- E2E テストを追加して `users` の一覧/作成/編集/削除フローをブラウザで検証できるようにするため。 
- ローカルや CI で実行しやすいように `PLAYWRIGHT_BASE_URL` で接続先を切り替え可能にするため。

### Description

- 追加した Playwright プロジェクトは `r01/e2e` に格納し、依存・実行スクリプトを `r01/e2e/package.json` に追加しました。 
- テスト設定は `r01/e2e/playwright.config.js` に追加し、テストディレクトリ・Chromium プロジェクト・`PLAYWRIGHT_BASE_URL` を定義しました。 
- E2E テスト `users` の CRUD シナリオを `r01/e2e/tests/users-crud.spec.js` として追加しました。 
- 実行手順を `r01/README.md` に追記しました（`r01/e2e` で `npm install` の後に `npm test` を実行）。

### Testing

- 試行した `docker compose up -d mysql mysql_test rails` はこの環境で `docker` コマンドが存在しないため失敗しました。 
- `npm install` を `r01/e2e` で実行しようとしましたが、npm レジストリへのアクセスが `403 Forbidden` となり依存導入ができず Playwright 実行確認は行えませんでした。 
- 変更はローカルでコミット済み（新規ファイル追加と `r01/README.md` 更新）で、自動テスト実行は上記環境制約により未実行です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991464d3c68832e9f218ec0dd94390a)